### PR TITLE
remove external from network to create automatically

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 services:
   app:
     image: suecharo/sapporo-service:1.0.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,4 @@ services:
 
 networks:
   sapporo:
-    external:
-      name: sapporo-network
+    name: sapporo-network

--- a/tests/unit_test/test_post_runs/cwltool/test_attach_all_files.py
+++ b/tests/unit_test/test_post_runs/cwltool/test_attach_all_files.py
@@ -44,7 +44,8 @@ def post_runs_attach_all_files_with_flask(
 def post_runs_attach_all_files() -> RunId:
     script_path = SCRIPT_DIR.joinpath("attach_all_files/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/cwltool/test_registered_only_mode_local.py
+++ b/tests/unit_test/test_post_runs/cwltool/test_registered_only_mode_local.py
@@ -14,7 +14,9 @@ def post_runs_registered_only_mode_local() -> RunId:
     script_path = \
         SCRIPT_DIR.joinpath("registered_only_mode_local/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/cwltool/test_registered_only_mode_remote.py
+++ b/tests/unit_test/test_post_runs/cwltool/test_registered_only_mode_remote.py
@@ -14,7 +14,9 @@ def post_runs_registered_only_mode_remote() -> RunId:
     script_path = \
         SCRIPT_DIR.joinpath("registered_only_mode_remote/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/cwltool/test_remote_workflow.py
+++ b/tests/unit_test/test_post_runs/cwltool/test_remote_workflow.py
@@ -37,7 +37,9 @@ def post_runs_remote_workflow_with_flask(
 def post_runs_remote_workflow() -> RunId:
     script_path = SCRIPT_DIR.joinpath("remote_workflow/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/cwltool/test_tags_workflow_name.py
+++ b/tests/unit_test/test_post_runs/cwltool/test_tags_workflow_name.py
@@ -14,7 +14,9 @@ def post_runs_tags_workflow_name() -> RunId:
     script_path = \
         SCRIPT_DIR.joinpath("tags_workflow_name/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/cwltool/test_workflow_engine_parameters.py
+++ b/tests/unit_test/test_post_runs/cwltool/test_workflow_engine_parameters.py
@@ -14,7 +14,9 @@ def post_runs_workflow_engine_parameters() -> RunId:
     script_path = \
         SCRIPT_DIR.joinpath("workflow_engine_parameters/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/nextflow/test_file_input.py
+++ b/tests/unit_test/test_post_runs/nextflow/test_file_input.py
@@ -13,7 +13,9 @@ from . import SCRIPT_DIR, TEST_HOST, TEST_PORT  # type: ignore
 def post_runs_file_input() -> RunId:
     script_path = SCRIPT_DIR.joinpath("file_input/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/nextflow/test_file_input_with_docker.py
+++ b/tests/unit_test/test_post_runs/nextflow/test_file_input_with_docker.py
@@ -13,7 +13,9 @@ from . import SCRIPT_DIR, TEST_HOST, TEST_PORT  # type: ignore
 def post_runs_file_input_with_docker() -> RunId:
     script_path = SCRIPT_DIR.joinpath("file_input_with_docker/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/nextflow/test_params_outdir.py
+++ b/tests/unit_test/test_post_runs/nextflow/test_params_outdir.py
@@ -13,7 +13,9 @@ from . import SCRIPT_DIR, TEST_HOST, TEST_PORT  # type: ignore
 def post_runs_params_outdir() -> RunId:
     script_path = SCRIPT_DIR.joinpath("params_outdir/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/nextflow/test_params_outdir_with_docker.py
+++ b/tests/unit_test/test_post_runs/nextflow/test_params_outdir_with_docker.py
@@ -13,7 +13,9 @@ from . import SCRIPT_DIR, TEST_HOST, TEST_PORT  # type: ignore
 def post_runs_params_outdir_with_docker() -> RunId:
     script_path = SCRIPT_DIR.joinpath("params_outdir_with_docker/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/nextflow/test_str_input.py
+++ b/tests/unit_test/test_post_runs/nextflow/test_str_input.py
@@ -13,7 +13,9 @@ from . import SCRIPT_DIR, TEST_HOST, TEST_PORT  # type: ignore
 def post_runs_str_input() -> RunId:
     script_path = SCRIPT_DIR.joinpath("str_input/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})

--- a/tests/unit_test/test_post_runs/nextflow/test_str_input_with_docker.py
+++ b/tests/unit_test/test_post_runs/nextflow/test_str_input_with_docker.py
@@ -13,7 +13,9 @@ from . import SCRIPT_DIR, TEST_HOST, TEST_PORT  # type: ignore
 def post_runs_str_input_with_docker() -> RunId:
     script_path = SCRIPT_DIR.joinpath("str_input_with_docker/post_runs.sh")
     proc = subprocess.run(shlex.split(f"/bin/bash {str(script_path)}"),
-                          capture_output=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+
                           encoding="utf-8",
                           env={"SAPPORO_HOST": TEST_HOST,
                                "SAPPORO_PORT": TEST_PORT})


### PR DESCRIPTION
`external` is the option to use the existing network - users need to create beforehand, which is a bit bothering. If there's any strong reason to keep this, just ignore this PR