### PR TITLE
Update ep3 from v1.0.0 to v1.7.0

### DIFF
--- a/sapporo/run.sh
+++ b/sapporo/run.sh
@@ -92,8 +92,8 @@ function run_snakemake() {
 }
 
 function run_ep3() {
-  local container="ghcr.io/tom-tan/ep3:v1.0.0"
-  local cmd_txt="${DOCKER_CMD} ${container} ep3-runner --debug --outdir ${outputs_dir} ${wf_engine_params} ${wf_url} ${wf_params} 1>${stdout} 2>${stderr}"
+  local container="ghcr.io/tom-tan/ep3:v1.7.0"
+  local cmd_txt="${DOCKER_CMD} ${container} ep3-runner --verbose --outdir ${outputs_dir} ${wf_engine_params} ${wf_url} ${wf_params} 1>${stdout} 2>${stderr}"
   echo ${cmd_txt} >${cmd}
   eval ${cmd_txt} || executor_error
 }

--- a/sapporo/service-info.json
+++ b/sapporo/service-info.json
@@ -21,7 +21,7 @@
     "toil (experimental)": "4.1.0",
     "cromwell": "55",
     "snakemake": "v5.32.0",
-    "ep3 (experimental)": "v1.0.0"
+    "ep3 (experimental)": "v1.7.0"
   },
   "auth_instructions_url": "https://github.com/ddbj/sapporo-service",
   "contact_info_url": "https://github.com/ddbj/sapporo-service",


### PR DESCRIPTION
It supports a metrics collection feature (compatible with [CWL-metrics](https://inutano.github.io/cwl-metrics/) format 0.2.0).
- Release note: https://github.com/tom-tan/ep3/releases/tag/v1.7.0
